### PR TITLE
Use repository secrets to define docker repo

### DIFF
--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -33,6 +33,6 @@ jobs:
       - name: Publish to Registry
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
-          name: jfandy1982/find-duplicates
+          name: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/update_dockerhub_description.yml
+++ b/.github/workflows/update_dockerhub_description.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Sync README from ./docs/docker/docker.md
         uses: meeDamian/sync-readme@v1.0.6
         with:
+          readme: ./docs/docker/docker.md
+          slug: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}
           user: ${{ secrets.DOCKERHUB_USERNAME }}
           pass: ${{ secrets.DOCKERHUB_PASSWORD }}
-          readme: ./docs/docker/docker.md
-          slug: jfandy1982/find-duplicates


### PR DESCRIPTION
The repository now needs to define these three repository secrets:
* `DOCKERHUB_USERNAME`: Login user and owner of the DockerHub repository
* `DOCKERHUB_PASSWORD`: Password for a login into DockerHub
* `DOCKERHUB_REPOSITORY`: target repository name on hub.docker.com owned by user defined with `DOCKERHUB_USERNAME`

These are used in the CI/CD workflows to push updates into the right docker repository.
