### PR TITLE
feat: add housekeeping workflow

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -1,0 +1,13 @@
+name: Housekeeping
+
+on:
+  schedule:
+    - cron: '23 04 * * 5'
+  workflow_dispatch:
+
+jobs:
+  retention:
+    uses: jfandy1982/shared-github-workflows/.github/workflows/reusable-retention-workflow-runs.yml@main
+    permissions:
+      actions: write
+      contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ Docker image wrapping the `fdupes` CLI tool to find duplicate files on a filesys
 ## Known Structure
 
 - `experiments/` — contains experimental attempts as well as test data for checking the functionality locally
+  - `experiments/superpowers/` — brainstorming specs and implementation plans from Claude sessions (gitignored, local only); check here for prior design decisions before starting new work
 - `node_modules/` — exists locally but is gitignored; not committed to the repo
 
 ## Tooling


### PR DESCRIPTION
## Summary

- Adds `housekeeping.yml` — local orchestrator for this repo, triggers weekly on Friday and on manual dispatch
- Updates CLAUDE.md to reflect tooling additions

## Notes

- Artifacts are deleted implicitly when their parent workflow run is deleted (GitHub behavior)