### PR TITLE
chore: add js-yaml validation and align tooling conventions

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,3 +1,4 @@
 {
-  "**/*.{json,md,yml,yaml}": ["prettier --write", "cspell lint --no-must-find-files --no-progress"]
+  "**/*.{json,md,yml,yaml}": ["prettier --write", "cspell lint --no-must-find-files --no-progress"],
+  "**/*.{yml,yaml}": ["js-yaml"]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Docker image wrapping the `fdupes` CLI tool to find duplicate files on a filesys
 
 - GitHub Actions SHAs are manually verified and pinned — do not flag pinned SHAs as outdated without checking first
 - Renovate: `renovate.json` in `.github/` is the repository-specific Renovate entry point; the `schedule` override there is intentional
-- pre-commit hook runs `lint-staged` (Prettier + cspell) on `*.json`, `*.md`, `*.yml`
+- pre-commit hook runs `lint-staged` (Prettier + cspell) on `*.json`, `*.md`, `*.yml`; additionally runs `js-yaml` syntax validation on `*.yml`, `*.yaml`
 
 ### Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,5 +23,7 @@ These NPM scripts can be used beside pre-commit-hooks to enforce proper spelling
 ```bash
 npm run format:all          # format all JSON/MD/YML files with Prettier
 npm run format:all:check    # verify formatting without writing
-npm run spell:check:all     # run cspell on the whole repo
+npm run spell:all:check     # run cspell on the whole repo
+npm run spell:dict:search   # search word in available dictionaries; reveals which dict to enable in .cspell.json
+npm run yaml:all:check      # validate YAML syntax in .github/workflows
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@cspell/dict-de-de": "^4.0.0",
         "cspell": "^9.0.0",
         "husky": "^9.0.0",
+        "js-yaml": "^4.1.1",
         "lint-staged": "^16.0.0",
         "prettier": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "format:all:check": "prettier --check .",
     "prepare": "husky || true",
     "spell:check:all": "cspell lint --dot --show-suggestions --no-progress --no-must-find-files --config ./.cspell.json .",
-    "spell:search:dict": "cspell trace --all --config ./.cspell.json"
+    "spell:search:dict": "cspell trace --all --config ./.cspell.json",
+    "yaml:all:check": "find .github/workflows -name '*.yml' -exec js-yaml {} \\;"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.1.0",
@@ -14,6 +15,7 @@
     "@cspell/dict-de-de": "^4.0.0",
     "cspell": "^9.0.0",
     "husky": "^9.0.0",
+    "js-yaml": "^4.1.1",
     "lint-staged": "^16.0.0",
     "prettier": "^3.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "format:all": "prettier --write .",
     "format:all:check": "prettier --check .",
     "prepare": "husky || true",
-    "spell:check:all": "cspell lint --dot --show-suggestions --no-progress --no-must-find-files --config ./.cspell.json .",
-    "spell:search:dict": "cspell trace --all --config ./.cspell.json",
+    "spell:all:check": "cspell lint --dot --show-suggestions --no-progress --no-must-find-files --config ./.cspell.json .",
+    "spell:dict:search": "cspell trace --all --config ./.cspell.json",
     "yaml:all:check": "find .github/workflows -name '*.yml' -exec js-yaml {} \\;"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Adds js-yaml as explicit devDependency for YAML syntax validation in lint-staged pre-commit hook
- Aligns npm script naming to consistent `<tool>:<scope>:<mode>` convention
- Updates CLAUDE.md to reflect new naming conventions and tooling additions incl. full script reference