### PR TITLE
feat: add actionlint workflow

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -20,6 +20,7 @@
   "loadDefaultConfiguration": true,
   "useGitignore": true,
   "ignoreWords": [
+    "actionlint",
     "coreutils",
     "debian",
     "dockerhub",

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,15 @@
+name: Local ActionLint
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+jobs:
+  actionlint:
+    name: Lint Workflow Files
+    uses: jfandy1982/shared-github-workflows/.github/workflows/reusable-actionlint.yml@main
+    permissions:
+      contents: read
+      pull-requests: write


### PR DESCRIPTION
## Summary

- Adds `actionlint.yml` — local caller workflow triggered on `pull_request` (scoped to `.github/workflows/**`) and `workflow_dispatch`
- Adds `actionlint` and `rhysd` to `.cspell.json` ignore list